### PR TITLE
fix: ensure single-row metadata table by using a fixed primary key in…

### DIFF
--- a/pkg/capec/local.go
+++ b/pkg/capec/local.go
@@ -220,9 +220,10 @@ func (s *LocalCAPECStore) ImportFromXML(xmlPath, xsdPath string, force bool) err
 	}
 	// persist catalog metadata
 	if catalogVersion != "" {
-		meta := CAPECCatalogMeta{Version: catalogVersion, Source: xmlPath, ImportedAtUTC: time.Now().UTC().Unix()}
-		// upsert single-row meta
-		if err := s.db.Clauses(clause.OnConflict{UpdateAll: true}).Create(&meta).Error; err != nil {
+		// Use a fixed primary key to ensure a single-row metadata table.
+		meta := CAPECCatalogMeta{ID: 1, Version: catalogVersion, Source: xmlPath, ImportedAtUTC: time.Now().UTC().Unix()}
+		// upsert single-row meta by primary key
+		if err := s.db.Clauses(clause.OnConflict{Columns: []clause.Column{{Name: "id"}}, UpdateAll: true}).Create(&meta).Error; err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
… ImportFromXML

## Summary by Sourcery

Bug Fixes:
- Fix CAPEC metadata upsert to target a fixed primary key so repeated imports update the single metadata row instead of creating duplicates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CAPEC catalog metadata handling to ensure consistent and reliable catalog management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->