### PR TITLE
test: adjust test levels from Level2 to Level1 for pure logic tests

### DIFF
--- a/cmd/v2broker/core/rpc_test.go
+++ b/cmd/v2broker/core/rpc_test.go
@@ -1,8 +1,8 @@
 package core
 
 import (
-"gorm.io/gorm"
-"github.com/cyw0ng95/v2e/pkg/testutils"
+	"github.com/cyw0ng95/v2e/pkg/testutils"
+	"gorm.io/gorm"
 	"testing"
 
 	"github.com/cyw0ng95/v2e/pkg/proc"
@@ -10,7 +10,7 @@ import (
 
 // TestBroker_RegisterEndpoint tests endpoint registration
 func TestBroker_RegisterEndpoint(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestBroker_RegisterEndpoint", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestBroker_RegisterEndpoint", nil, func(t *testing.T, tx *gorm.DB) {
 		broker := NewBroker()
 		defer broker.Shutdown()
 
@@ -32,7 +32,7 @@ func TestBroker_RegisterEndpoint(t *testing.T) {
 
 // TestBroker_GetAllEndpoints tests getting all endpoints
 func TestBroker_GetAllEndpoints(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestBroker_GetAllEndpoints", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestBroker_GetAllEndpoints", nil, func(t *testing.T, tx *gorm.DB) {
 		broker := NewBroker()
 		defer broker.Shutdown()
 
@@ -61,7 +61,7 @@ func TestBroker_GetAllEndpoints(t *testing.T) {
 }
 
 func TestHandleRPCGetMessageStats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestHandleRPCGetMessageStats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestHandleRPCGetMessageStats", nil, func(t *testing.T, tx *gorm.DB) {
 		broker := NewBroker()
 		defer broker.Shutdown()
 
@@ -119,7 +119,7 @@ func TestHandleRPCGetMessageStats(t *testing.T) {
 }
 
 func TestHandleRPCGetMessageCount(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestHandleRPCGetMessageCount", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestHandleRPCGetMessageCount", nil, func(t *testing.T, tx *gorm.DB) {
 		broker := NewBroker()
 		defer broker.Shutdown()
 
@@ -179,7 +179,7 @@ func TestHandleRPCGetMessageCount(t *testing.T) {
 }
 
 func TestProcessMessage_RPCGetMessageStats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestProcessMessage_RPCGetMessageStats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestProcessMessage_RPCGetMessageStats", nil, func(t *testing.T, tx *gorm.DB) {
 		broker := NewBroker()
 		defer broker.Shutdown()
 
@@ -207,7 +207,7 @@ func TestProcessMessage_RPCGetMessageStats(t *testing.T) {
 }
 
 func TestProcessMessage_UnknownRPC(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestProcessMessage_UnknownRPC", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestProcessMessage_UnknownRPC", nil, func(t *testing.T, tx *gorm.DB) {
 		broker := NewBroker()
 		defer broker.Shutdown()
 

--- a/cmd/v2broker/mq/bus_test.go
+++ b/cmd/v2broker/mq/bus_test.go
@@ -1,10 +1,10 @@
 package mq
 
 import (
-"gorm.io/gorm"
-"github.com/cyw0ng95/v2e/pkg/testutils"
 	"context"
 	"errors"
+	"github.com/cyw0ng95/v2e/pkg/testutils"
+	"gorm.io/gorm"
 	"testing"
 	"time"
 
@@ -12,7 +12,7 @@ import (
 )
 
 func TestBusSendReceiveStats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestBusSendReceiveStats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestBusSendReceiveStats", nil, func(t *testing.T, tx *gorm.DB) {
 		ctx := context.Background()
 		bus := NewBus(ctx, 4)
 
@@ -66,7 +66,7 @@ func TestBusSendReceiveStats(t *testing.T) {
 }
 
 func TestBusSendCanceled(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestBusSendCanceled", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestBusSendCanceled", nil, func(t *testing.T, tx *gorm.DB) {
 		bus := NewBus(context.Background(), 0)
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -80,7 +80,7 @@ func TestBusSendCanceled(t *testing.T) {
 }
 
 func TestBusSendOnClosedChannel(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestBusSendOnClosedChannel", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestBusSendOnClosedChannel", nil, func(t *testing.T, tx *gorm.DB) {
 		bus := NewBus(context.Background(), 1)
 		bus.Close()
 
@@ -96,7 +96,7 @@ func TestBusSendOnClosedChannel(t *testing.T) {
 }
 
 func TestBusReceiveCanceled(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestBusReceiveCanceled", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestBusReceiveCanceled", nil, func(t *testing.T, tx *gorm.DB) {
 		bus := NewBus(context.Background(), 1)
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
@@ -109,7 +109,7 @@ func TestBusReceiveCanceled(t *testing.T) {
 }
 
 func TestSendRespectsBusContext(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestSendRespectsBusContext", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestSendRespectsBusContext", nil, func(t *testing.T, tx *gorm.DB) {
 		busCtx, cancelBus := context.WithCancel(context.Background())
 		bus := NewBus(busCtx, 0)
 		cancelBus()
@@ -123,7 +123,7 @@ func TestSendRespectsBusContext(t *testing.T) {
 }
 
 func TestFirstAndLastMessageTimesSet(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestFirstAndLastMessageTimesSet", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestFirstAndLastMessageTimesSet", nil, func(t *testing.T, tx *gorm.DB) {
 		bus := NewBus(context.Background(), 1)
 		msg := &proc.Message{Type: proc.MessageTypeEvent, Source: "s", Target: "t"}
 

--- a/pkg/attack/types_format_test.go
+++ b/pkg/attack/types_format_test.go
@@ -1,17 +1,17 @@
 package attack
 
 import (
-"gorm.io/gorm"
-"github.com/cyw0ng95/v2e/pkg/testutils"
 	"encoding/json"
 	"fmt"
+	"github.com/cyw0ng95/v2e/pkg/testutils"
+	"gorm.io/gorm"
 	"strings"
 	"testing"
 )
 
 // TestAttackTechnique_JSONMarshalUnmarshal covers ATT&CK technique JSON serialization.
 func TestAttackTechnique_JSONMarshalUnmarshal(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestAttackTechnique_JSONMarshalUnmarshal", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestAttackTechnique_JSONMarshalUnmarshal", nil, func(t *testing.T, tx *gorm.DB) {
 		cases := []struct {
 			name      string
 			technique AttackTechnique
@@ -103,7 +103,7 @@ func TestAttackTechnique_JSONMarshalUnmarshal(t *testing.T) {
 
 // TestAttackTactic_JSONFormats covers ATT&CK tactic JSON serialization.
 func TestAttackTactic_JSONFormats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestAttackTactic_JSONFormats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestAttackTactic_JSONFormats", nil, func(t *testing.T, tx *gorm.DB) {
 		cases := []struct {
 			name   string
 			tactic AttackTactic
@@ -164,7 +164,7 @@ func TestAttackTactic_JSONFormats(t *testing.T) {
 
 // TestAttackTechnique_IDFormats validates various technique ID formats.
 func TestAttackTechnique_IDFormats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestAttackTechnique_IDFormats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestAttackTechnique_IDFormats", nil, func(t *testing.T, tx *gorm.DB) {
 		validIDs := []string{
 			"T1001",
 			"T1002",
@@ -200,7 +200,7 @@ func TestAttackTechnique_IDFormats(t *testing.T) {
 
 // TestAttackTactic_IDFormats validates various tactic ID formats.
 func TestAttackTactic_IDFormats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestAttackTactic_IDFormats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestAttackTactic_IDFormats", nil, func(t *testing.T, tx *gorm.DB) {
 		validIDs := []string{
 			"TA0001",
 			"TA0002",
@@ -233,7 +233,7 @@ func TestAttackTactic_IDFormats(t *testing.T) {
 
 // TestAttackTechnique_DomainValues validates domain field values.
 func TestAttackTechnique_DomainValues(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestAttackTechnique_DomainValues", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestAttackTechnique_DomainValues", nil, func(t *testing.T, tx *gorm.DB) {
 		domains := []string{
 			"enterprise-attack",
 			"mobile-attack",
@@ -265,7 +265,7 @@ func TestAttackTechnique_DomainValues(t *testing.T) {
 
 // TestAttackTechnique_PlatformValues validates platform field values.
 func TestAttackTechnique_PlatformValues(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestAttackTechnique_PlatformValues", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestAttackTechnique_PlatformValues", nil, func(t *testing.T, tx *gorm.DB) {
 		platforms := []string{
 			"Windows",
 			"Linux",
@@ -302,7 +302,7 @@ func TestAttackTechnique_PlatformValues(t *testing.T) {
 
 // TestAttackMitigation_JSONFormats validates mitigation JSON serialization.
 func TestAttackMitigation_JSONFormats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestAttackMitigation_JSONFormats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestAttackMitigation_JSONFormats", nil, func(t *testing.T, tx *gorm.DB) {
 		cases := []struct {
 			name       string
 			mitigation AttackMitigation
@@ -343,7 +343,7 @@ func TestAttackMitigation_JSONFormats(t *testing.T) {
 
 // TestAttackSoftware_JSONFormats validates software JSON serialization.
 func TestAttackSoftware_JSONFormats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestAttackSoftware_JSONFormats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestAttackSoftware_JSONFormats", nil, func(t *testing.T, tx *gorm.DB) {
 		cases := []struct {
 			name     string
 			software AttackSoftware
@@ -376,7 +376,7 @@ func TestAttackSoftware_JSONFormats(t *testing.T) {
 
 // TestAttackGroup_JSONFormats validates group JSON serialization.
 func TestAttackGroup_JSONFormats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestAttackGroup_JSONFormats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestAttackGroup_JSONFormats", nil, func(t *testing.T, tx *gorm.DB) {
 		cases := []struct {
 			name  string
 			group AttackGroup

--- a/pkg/attack/types_test.go
+++ b/pkg/attack/types_test.go
@@ -1,8 +1,8 @@
 package attack
 
 import (
-"gorm.io/gorm"
-"github.com/cyw0ng95/v2e/pkg/testutils"
+	"github.com/cyw0ng95/v2e/pkg/testutils"
+	"gorm.io/gorm"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,7 +10,7 @@ import (
 
 func TestAttackTypes_Structs(t *testing.T) {
 	// Test AttackTechnique struct
-	testutils.Run(t, testutils.Level2, "AttackTechnique", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "AttackTechnique", nil, func(t *testing.T, tx *gorm.DB) {
 		tech := AttackTechnique{
 			ID:          "T1001",
 			Name:        "Test Technique",
@@ -35,7 +35,7 @@ func TestAttackTypes_Structs(t *testing.T) {
 	})
 
 	// Test AttackTactic struct
-	testutils.Run(t, testutils.Level2, "AttackTactic", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "AttackTactic", nil, func(t *testing.T, tx *gorm.DB) {
 		tactic := AttackTactic{
 			ID:          "TA0001",
 			Name:        "Test Tactic",
@@ -54,7 +54,7 @@ func TestAttackTypes_Structs(t *testing.T) {
 	})
 
 	// Test AttackMitigation struct
-	testutils.Run(t, testutils.Level2, "AttackMitigation", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "AttackMitigation", nil, func(t *testing.T, tx *gorm.DB) {
 		mitigation := AttackMitigation{
 			ID:          "M1001",
 			Name:        "Test Mitigation",
@@ -73,7 +73,7 @@ func TestAttackTypes_Structs(t *testing.T) {
 	})
 
 	// Test AttackSoftware struct
-	testutils.Run(t, testutils.Level2, "AttackSoftware", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "AttackSoftware", nil, func(t *testing.T, tx *gorm.DB) {
 		software := AttackSoftware{
 			ID:          "S0001",
 			Name:        "Test Software",
@@ -94,7 +94,7 @@ func TestAttackTypes_Structs(t *testing.T) {
 	})
 
 	// Test AttackGroup struct
-	testutils.Run(t, testutils.Level2, "AttackGroup", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "AttackGroup", nil, func(t *testing.T, tx *gorm.DB) {
 		group := AttackGroup{
 			ID:          "G0001",
 			Name:        "Test Group",
@@ -113,7 +113,7 @@ func TestAttackTypes_Structs(t *testing.T) {
 	})
 
 	// Test AttackRelationship struct
-	testutils.Run(t, testutils.Level2, "AttackRelationship", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "AttackRelationship", nil, func(t *testing.T, tx *gorm.DB) {
 		relationship := AttackRelationship{
 			ID:               "rel-1",
 			SourceRef:        "T1001",
@@ -140,7 +140,7 @@ func TestAttackTypes_Structs(t *testing.T) {
 	})
 
 	// Test AttackMetadata struct
-	testutils.Run(t, testutils.Level2, "AttackMetadata", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "AttackMetadata", nil, func(t *testing.T, tx *gorm.DB) {
 		metadata := AttackMetadata{
 			ID:            1,
 			ImportedAt:    1234567890,

--- a/pkg/broker/api_test.go
+++ b/pkg/broker/api_test.go
@@ -1,9 +1,9 @@
 package broker
 
 import (
-	"testing"
 	"github.com/cyw0ng95/v2e/pkg/testutils"
 	"gorm.io/gorm"
+	"testing"
 )
 
 // fakeSpawner implements Spawner for compile-time contract testing.
@@ -21,14 +21,14 @@ func (fakeSpawner) SpawnRPCWithRestart(id, command string, maxRestarts int, args
 }
 
 func TestSpawnerInterfaceCompilation(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestSpawnerInterfaceCompilation", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestSpawnerInterfaceCompilation", nil, func(t *testing.T, tx *gorm.DB) {
 		var _ Spawner = fakeSpawner{}
 	})
 
 }
 
 func TestSpawnResultFields(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestSpawnResultFields", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestSpawnResultFields", nil, func(t *testing.T, tx *gorm.DB) {
 		res := SpawnResult{ID: "pid", PID: 123, Command: "echo", Args: []string{"hi"}, Status: "running", ExitCode: 0}
 		if res.ID != "pid" || res.PID != 123 || res.Command != "echo" || res.Status != "running" || res.ExitCode != 0 {
 			t.Fatalf("unexpected spawn result: %+v", res)

--- a/pkg/capec/types_format_test.go
+++ b/pkg/capec/types_format_test.go
@@ -1,17 +1,17 @@
 package capec
 
 import (
-"gorm.io/gorm"
-"github.com/cyw0ng95/v2e/pkg/testutils"
 	"encoding/xml"
 	"fmt"
+	"github.com/cyw0ng95/v2e/pkg/testutils"
+	"gorm.io/gorm"
 	"strings"
 	"testing"
 )
 
 // TestCAPECAttackPattern_XMLMarshalUnmarshal covers CAPEC XML serialization edge cases.
 func TestCAPECAttackPattern_XMLMarshalUnmarshal(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCAPECAttackPattern_XMLMarshalUnmarshal", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCAPECAttackPattern_XMLMarshalUnmarshal", nil, func(t *testing.T, tx *gorm.DB) {
 		cases := []struct {
 			name    string
 			pattern CAPECAttackPattern
@@ -212,7 +212,7 @@ func TestCAPECAttackPattern_XMLMarshalUnmarshal(t *testing.T) {
 
 // TestInnerXML_Formats covers InnerXML content variations.
 func TestInnerXML_Formats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestInnerXML_Formats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestInnerXML_Formats", nil, func(t *testing.T, tx *gorm.DB) {
 		cases := []struct {
 			name string
 			xml  string
@@ -257,7 +257,7 @@ func TestInnerXML_Formats(t *testing.T) {
 
 // TestRelatedWeakness_Formats covers CWE ID format variations.
 func TestRelatedWeakness_Formats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestRelatedWeakness_Formats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestRelatedWeakness_Formats", nil, func(t *testing.T, tx *gorm.DB) {
 		cweIDs := []string{
 			"CWE-1",
 			"CWE-79",
@@ -298,7 +298,7 @@ func TestRelatedWeakness_Formats(t *testing.T) {
 
 // TestCAPECAttackPattern_IDRanges validates various CAPEC ID values.
 func TestCAPECAttackPattern_IDRanges(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCAPECAttackPattern_IDRanges", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCAPECAttackPattern_IDRanges", nil, func(t *testing.T, tx *gorm.DB) {
 		ids := []int{1, 10, 100, 500, 1000, 9999}
 
 		for _, id := range ids {
@@ -325,7 +325,7 @@ func TestCAPECAttackPattern_IDRanges(t *testing.T) {
 
 // TestCAPECAttackPattern_AbstractionLevels validates abstraction values.
 func TestCAPECAttackPattern_AbstractionLevels(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCAPECAttackPattern_AbstractionLevels", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCAPECAttackPattern_AbstractionLevels", nil, func(t *testing.T, tx *gorm.DB) {
 		abstractions := []string{
 			"Meta",
 			"Standard",
@@ -357,7 +357,7 @@ func TestCAPECAttackPattern_AbstractionLevels(t *testing.T) {
 
 // TestCAPECAttackPattern_StatusValues validates status values.
 func TestCAPECAttackPattern_StatusValues(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCAPECAttackPattern_StatusValues", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCAPECAttackPattern_StatusValues", nil, func(t *testing.T, tx *gorm.DB) {
 		statuses := []string{
 			"Draft",
 			"Stable",
@@ -390,7 +390,7 @@ func TestCAPECAttackPattern_StatusValues(t *testing.T) {
 
 // TestCAPECAttackPattern_LikelihoodValues validates likelihood values.
 func TestCAPECAttackPattern_LikelihoodValues(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCAPECAttackPattern_LikelihoodValues", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCAPECAttackPattern_LikelihoodValues", nil, func(t *testing.T, tx *gorm.DB) {
 		likelihoods := []string{
 			"High",
 			"Medium",
@@ -422,7 +422,7 @@ func TestCAPECAttackPattern_LikelihoodValues(t *testing.T) {
 
 // TestCAPECAttackPattern_SeverityValues validates severity values.
 func TestCAPECAttackPattern_SeverityValues(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCAPECAttackPattern_SeverityValues", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCAPECAttackPattern_SeverityValues", nil, func(t *testing.T, tx *gorm.DB) {
 		severities := []string{
 			"Very High",
 			"High",
@@ -456,7 +456,7 @@ func TestCAPECAttackPattern_SeverityValues(t *testing.T) {
 
 // TestCAPECAttackPattern_ArraySizes validates various array sizes.
 func TestCAPECAttackPattern_ArraySizes(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCAPECAttackPattern_ArraySizes", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCAPECAttackPattern_ArraySizes", nil, func(t *testing.T, tx *gorm.DB) {
 		sizes := []int{0, 1, 5, 10, 50}
 
 		for _, size := range sizes {

--- a/pkg/capec/types_test.go
+++ b/pkg/capec/types_test.go
@@ -1,14 +1,14 @@
 package capec
 
 import (
-"gorm.io/gorm"
-"github.com/cyw0ng95/v2e/pkg/testutils"
 	"encoding/xml"
+	"github.com/cyw0ng95/v2e/pkg/testutils"
+	"gorm.io/gorm"
 	"testing"
 )
 
 func TestCAPECAttackPattern_Unmarshal(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCAPECAttackPattern_Unmarshal", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCAPECAttackPattern_Unmarshal", nil, func(t *testing.T, tx *gorm.DB) {
 		data := `<?xml version="1.0"?>
 	    <Attack_Pattern ID="123" Name="Test Pattern" Abstraction="Detailed" Status="Stable">
 	      <Summary>Short summary</Summary>

--- a/pkg/common/log_test.go
+++ b/pkg/common/log_test.go
@@ -1,9 +1,9 @@
 package common
 
 import (
-"gorm.io/gorm"
-"github.com/cyw0ng95/v2e/pkg/testutils"
 	"bytes"
+	"github.com/cyw0ng95/v2e/pkg/testutils"
+	"gorm.io/gorm"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,7 +11,7 @@ import (
 )
 
 func TestLogLevel_String(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestLogLevel_String", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestLogLevel_String", nil, func(t *testing.T, tx *gorm.DB) {
 		tests := []struct {
 			level    LogLevel
 			expected string
@@ -35,7 +35,7 @@ func TestLogLevel_String(t *testing.T) {
 }
 
 func TestNewLogger(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestNewLogger", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestNewLogger", nil, func(t *testing.T, tx *gorm.DB) {
 		var buf bytes.Buffer
 		logger := NewLogger(&buf, "TEST: ", InfoLevel)
 
@@ -51,7 +51,7 @@ func TestNewLogger(t *testing.T) {
 }
 
 func TestLogger_SetLevel(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestLogger_SetLevel", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestLogger_SetLevel", nil, func(t *testing.T, tx *gorm.DB) {
 		var buf bytes.Buffer
 		logger := NewLogger(&buf, "", InfoLevel)
 
@@ -69,7 +69,7 @@ func TestLogger_SetLevel(t *testing.T) {
 }
 
 func TestLogger_Debug(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestLogger_Debug", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestLogger_Debug", nil, func(t *testing.T, tx *gorm.DB) {
 		var buf bytes.Buffer
 		logger := NewLogger(&buf, "", DebugLevel)
 
@@ -90,7 +90,7 @@ func TestLogger_Debug(t *testing.T) {
 }
 
 func TestLogger_Info(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestLogger_Info", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestLogger_Info", nil, func(t *testing.T, tx *gorm.DB) {
 		var buf bytes.Buffer
 		logger := NewLogger(&buf, "", InfoLevel)
 
@@ -108,7 +108,7 @@ func TestLogger_Info(t *testing.T) {
 }
 
 func TestLogger_Warn(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestLogger_Warn", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestLogger_Warn", nil, func(t *testing.T, tx *gorm.DB) {
 		var buf bytes.Buffer
 		logger := NewLogger(&buf, "", WarnLevel)
 
@@ -126,7 +126,7 @@ func TestLogger_Warn(t *testing.T) {
 }
 
 func TestLogger_Error(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestLogger_Error", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestLogger_Error", nil, func(t *testing.T, tx *gorm.DB) {
 		var buf bytes.Buffer
 		logger := NewLogger(&buf, "", ErrorLevel)
 
@@ -144,7 +144,7 @@ func TestLogger_Error(t *testing.T) {
 }
 
 func TestLogger_LevelFiltering(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestLogger_LevelFiltering", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestLogger_LevelFiltering", nil, func(t *testing.T, tx *gorm.DB) {
 		tests := []struct {
 			name         string
 			loggerLevel  LogLevel
@@ -198,7 +198,7 @@ func TestLogger_LevelFiltering(t *testing.T) {
 }
 
 func TestLogger_SetOutput(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestLogger_SetOutput", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestLogger_SetOutput", nil, func(t *testing.T, tx *gorm.DB) {
 		var buf1 bytes.Buffer
 		var buf2 bytes.Buffer
 
@@ -225,7 +225,7 @@ func TestLogger_SetOutput(t *testing.T) {
 }
 
 func TestLogger_FormatString(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestLogger_FormatString", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestLogger_FormatString", nil, func(t *testing.T, tx *gorm.DB) {
 		var buf bytes.Buffer
 		logger := NewLogger(&buf, "", InfoLevel)
 
@@ -240,7 +240,7 @@ func TestLogger_FormatString(t *testing.T) {
 }
 
 func TestDefaultLogger(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestDefaultLogger", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestDefaultLogger", nil, func(t *testing.T, tx *gorm.DB) {
 		// Test that default logger functions work
 		var buf bytes.Buffer
 		SetOutput(&buf)
@@ -260,7 +260,7 @@ func TestDefaultLogger(t *testing.T) {
 }
 
 func TestDefaultLogger_AllLevels(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestDefaultLogger_AllLevels", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestDefaultLogger_AllLevels", nil, func(t *testing.T, tx *gorm.DB) {
 		var buf bytes.Buffer
 		SetOutput(&buf)
 		SetLevel(DebugLevel)
@@ -293,7 +293,7 @@ func TestDefaultLogger_AllLevels(t *testing.T) {
 }
 
 func TestGetLevel(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestGetLevel", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestGetLevel", nil, func(t *testing.T, tx *gorm.DB) {
 		// Save original level
 		originalLevel := GetLevel()
 		defer SetLevel(originalLevel)
@@ -312,7 +312,7 @@ func TestGetLevel(t *testing.T) {
 }
 
 func TestNewLoggerWithFile(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestNewLoggerWithFile", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestNewLoggerWithFile", nil, func(t *testing.T, tx *gorm.DB) {
 		tmpDir := t.TempDir()
 		fname := filepath.Join(tmpDir, "testlog.log")
 

--- a/pkg/common/workerpool/workerpool_test.go
+++ b/pkg/common/workerpool/workerpool_test.go
@@ -1,16 +1,16 @@
 package workerpool
 
 import (
-"gorm.io/gorm"
-"github.com/cyw0ng95/v2e/pkg/testutils"
 	"context"
+	"github.com/cyw0ng95/v2e/pkg/testutils"
+	"gorm.io/gorm"
 	"sync/atomic"
 	"testing"
 	"time"
 )
 
 func TestWorkerPoolCreation(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestWorkerPoolCreation", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestWorkerPoolCreation", nil, func(t *testing.T, tx *gorm.DB) {
 		config := &Config{
 			InitialSize: 4,
 			MinSize:     2,
@@ -29,7 +29,7 @@ func TestWorkerPoolCreation(t *testing.T) {
 }
 
 func TestWorkerPoolSubmitTask(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestWorkerPoolSubmitTask", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestWorkerPoolSubmitTask", nil, func(t *testing.T, tx *gorm.DB) {
 		pool := NewWorkerPool(nil) // Use defaults
 		defer pool.Close()
 
@@ -55,7 +55,7 @@ func TestWorkerPoolSubmitTask(t *testing.T) {
 }
 
 func TestWorkerPoolConcurrentTasks(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestWorkerPoolConcurrentTasks", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestWorkerPoolConcurrentTasks", nil, func(t *testing.T, tx *gorm.DB) {
 		pool := NewWorkerPool(&Config{
 			InitialSize: 4,
 			MinSize:     2,
@@ -90,7 +90,7 @@ func TestWorkerPoolConcurrentTasks(t *testing.T) {
 }
 
 func TestWorkerPoolResize(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestWorkerPoolResize", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestWorkerPoolResize", nil, func(t *testing.T, tx *gorm.DB) {
 		pool := NewWorkerPool(&Config{
 			InitialSize: 4,
 			MinSize:     2,
@@ -132,7 +132,7 @@ func TestWorkerPoolResize(t *testing.T) {
 }
 
 func TestWorkerPoolClose(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestWorkerPoolClose", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestWorkerPoolClose", nil, func(t *testing.T, tx *gorm.DB) {
 		pool := NewWorkerPool(nil)
 
 		// Submit some tasks
@@ -163,7 +163,7 @@ func TestWorkerPoolClose(t *testing.T) {
 }
 
 func TestWorkerPoolQueueDepth(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestWorkerPoolQueueDepth", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestWorkerPoolQueueDepth", nil, func(t *testing.T, tx *gorm.DB) {
 		pool := NewWorkerPool(&Config{
 			InitialSize: 1, // Only 1 worker
 			MinSize:     1,

--- a/pkg/cve/taskflow/state_test.go
+++ b/pkg/cve/taskflow/state_test.go
@@ -1,13 +1,13 @@
 package taskflow
 
 import (
-	"testing"
 	"github.com/cyw0ng95/v2e/pkg/testutils"
 	"gorm.io/gorm"
+	"testing"
 )
 
 func TestJobState_IsTerminal(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestJobState_IsTerminal", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestJobState_IsTerminal", nil, func(t *testing.T, tx *gorm.DB) {
 		terminal := []JobState{StateCompleted, StateFailed, StateStopped}
 		nonTerminal := []JobState{StateQueued, StateRunning, StatePaused}
 
@@ -27,7 +27,7 @@ func TestJobState_IsTerminal(t *testing.T) {
 }
 
 func TestJobState_CanTransitionTo_Matrix(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestJobState_CanTransitionTo_Matrix", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestJobState_CanTransitionTo_Matrix", nil, func(t *testing.T, tx *gorm.DB) {
 		states := []JobState{StateQueued, StateRunning, StatePaused, StateCompleted, StateFailed, StateStopped}
 
 		allowed := map[JobState]map[JobState]bool{

--- a/pkg/cve/types_format_test.go
+++ b/pkg/cve/types_format_test.go
@@ -1,17 +1,17 @@
 package cve
 
 import (
-"gorm.io/gorm"
-"github.com/cyw0ng95/v2e/pkg/testutils"
 	"encoding/json"
 	"fmt"
+	"github.com/cyw0ng95/v2e/pkg/testutils"
+	"gorm.io/gorm"
 	"strings"
 	"testing"
 )
 
 // TestCVEItem_JSONMarshalUnmarshal covers CVE JSON serialization edge cases.
 func TestCVEItem_JSONMarshalUnmarshal(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCVEItem_JSONMarshalUnmarshal", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCVEItem_JSONMarshalUnmarshal", nil, func(t *testing.T, tx *gorm.DB) {
 		cases := []struct {
 			name string
 			item CVEItem
@@ -114,7 +114,7 @@ func TestCVEItem_JSONMarshalUnmarshal(t *testing.T) {
 
 // TestCVEItem_IDFormats validates various CVE ID formats.
 func TestCVEItem_IDFormats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCVEItem_IDFormats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCVEItem_IDFormats", nil, func(t *testing.T, tx *gorm.DB) {
 		validIDs := []string{
 			"CVE-1999-0001",
 			"CVE-2000-0001",
@@ -148,7 +148,7 @@ func TestCVEItem_IDFormats(t *testing.T) {
 
 // TestDescription_Formats validates description edge cases.
 func TestDescription_Formats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestDescription_Formats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestDescription_Formats", nil, func(t *testing.T, tx *gorm.DB) {
 		cases := []struct {
 			name string
 			desc Description
@@ -186,7 +186,7 @@ func TestDescription_Formats(t *testing.T) {
 
 // TestReference_URLFormats validates reference URL edge cases.
 func TestReference_URLFormats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestReference_URLFormats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestReference_URLFormats", nil, func(t *testing.T, tx *gorm.DB) {
 		urls := []string{
 			"http://example.com",
 			"https://example.com",
@@ -221,7 +221,7 @@ func TestReference_URLFormats(t *testing.T) {
 
 // TestCVEItem_StatusValues validates vulnerability status values.
 func TestCVEItem_StatusValues(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCVEItem_StatusValues", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCVEItem_StatusValues", nil, func(t *testing.T, tx *gorm.DB) {
 		statuses := []string{
 			"Analyzed",
 			"Modified",
@@ -256,7 +256,7 @@ func TestCVEItem_StatusValues(t *testing.T) {
 
 // TestCVEResponse_JSONFormats validates top-level response structure.
 func TestCVEResponse_JSONFormats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCVEResponse_JSONFormats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCVEResponse_JSONFormats", nil, func(t *testing.T, tx *gorm.DB) {
 		cases := []struct {
 			name string
 			resp CVEResponse

--- a/pkg/cve/types_test.go
+++ b/pkg/cve/types_test.go
@@ -1,15 +1,15 @@
 package cve
 
 import (
-"gorm.io/gorm"
-"github.com/cyw0ng95/v2e/pkg/testutils"
 	"encoding/json"
+	"github.com/cyw0ng95/v2e/pkg/testutils"
+	"gorm.io/gorm"
 	"testing"
 	"time"
 )
 
 func TestNVDTime_UnmarshalJSON(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestNVDTime_UnmarshalJSON", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestNVDTime_UnmarshalJSON", nil, func(t *testing.T, tx *gorm.DB) {
 		tests := []struct {
 			name     string
 			input    string
@@ -74,7 +74,7 @@ func TestNVDTime_UnmarshalJSON(t *testing.T) {
 }
 
 func TestNVDTime_MarshalJSON(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestNVDTime_MarshalJSON", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestNVDTime_MarshalJSON", nil, func(t *testing.T, tx *gorm.DB) {
 		tests := []struct {
 			name     string
 			time     time.Time
@@ -110,7 +110,7 @@ func TestNVDTime_MarshalJSON(t *testing.T) {
 }
 
 func TestNewNVDTime(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestNewNVDTime", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestNewNVDTime", nil, func(t *testing.T, tx *gorm.DB) {
 		now := time.Now()
 		nvdTime := NewNVDTime(now)
 
@@ -122,7 +122,7 @@ func TestNewNVDTime(t *testing.T) {
 }
 
 func TestNVDTime_RoundTrip(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestNVDTime_RoundTrip", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestNVDTime_RoundTrip", nil, func(t *testing.T, tx *gorm.DB) {
 		original := NVDTime{Time: time.Date(2021, 12, 10, 10, 15, 9, 143000000, time.UTC)}
 
 		// Marshal

--- a/pkg/cwe/types_format_test.go
+++ b/pkg/cwe/types_format_test.go
@@ -1,17 +1,17 @@
 package cwe
 
 import (
-"gorm.io/gorm"
-"github.com/cyw0ng95/v2e/pkg/testutils"
 	"encoding/json"
 	"fmt"
+	"github.com/cyw0ng95/v2e/pkg/testutils"
+	"gorm.io/gorm"
 	"strings"
 	"testing"
 )
 
 // TestCWEItem_JSONMarshalUnmarshal covers CWE JSON serialization edge cases.
 func TestCWEItem_JSONMarshalUnmarshal(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCWEItem_JSONMarshalUnmarshal", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCWEItem_JSONMarshalUnmarshal", nil, func(t *testing.T, tx *gorm.DB) {
 		cases := []struct {
 			name string
 			item CWEItem
@@ -85,7 +85,7 @@ func TestCWEItem_JSONMarshalUnmarshal(t *testing.T) {
 
 // TestCWEItem_IDFormats validates various CWE ID formats.
 func TestCWEItem_IDFormats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCWEItem_IDFormats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCWEItem_IDFormats", nil, func(t *testing.T, tx *gorm.DB) {
 		validIDs := []string{
 			"CWE-1",
 			"CWE-79",
@@ -119,7 +119,7 @@ func TestCWEItem_IDFormats(t *testing.T) {
 
 // TestCWEItem_AbstractionValues validates abstraction enumeration values.
 func TestCWEItem_AbstractionValues(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCWEItem_AbstractionValues", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCWEItem_AbstractionValues", nil, func(t *testing.T, tx *gorm.DB) {
 		abstractions := []string{
 			"Class",
 			"Base",
@@ -152,7 +152,7 @@ func TestCWEItem_AbstractionValues(t *testing.T) {
 
 // TestCWEItem_StatusValues validates status enumeration values.
 func TestCWEItem_StatusValues(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCWEItem_StatusValues", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCWEItem_StatusValues", nil, func(t *testing.T, tx *gorm.DB) {
 		statuses := []string{
 			"Draft",
 			"Incomplete",
@@ -186,7 +186,7 @@ func TestCWEItem_StatusValues(t *testing.T) {
 
 // TestCWEItem_LikelihoodValues validates likelihood enumeration values.
 func TestCWEItem_LikelihoodValues(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCWEItem_LikelihoodValues", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCWEItem_LikelihoodValues", nil, func(t *testing.T, tx *gorm.DB) {
 		likelihoods := []string{
 			"High",
 			"Medium",
@@ -219,7 +219,7 @@ func TestCWEItem_LikelihoodValues(t *testing.T) {
 
 // TestRelatedWeakness_Formats validates related weakness edge cases.
 func TestRelatedWeakness_Formats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestRelatedWeakness_Formats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestRelatedWeakness_Formats", nil, func(t *testing.T, tx *gorm.DB) {
 		cases := []struct {
 			name     string
 			weakness RelatedWeakness
@@ -259,7 +259,7 @@ func TestRelatedWeakness_Formats(t *testing.T) {
 
 // TestApplicablePlatform_Formats validates platform edge cases.
 func TestApplicablePlatform_Formats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestApplicablePlatform_Formats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestApplicablePlatform_Formats", nil, func(t *testing.T, tx *gorm.DB) {
 		platforms := []ApplicablePlatform{
 			{Type: "Language", Name: "Java", Prevalence: "Often"},
 			{Type: "Language", Name: "C", Prevalence: "Often"},
@@ -296,7 +296,7 @@ func TestApplicablePlatform_Formats(t *testing.T) {
 
 // TestReference_Formats validates reference structure.
 func TestReference_Formats(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestReference_Formats", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestReference_Formats", nil, func(t *testing.T, tx *gorm.DB) {
 		refs := []Reference{
 			{ExternalReferenceID: "REF-1", URL: "https://example.com"},
 			{ExternalReferenceID: "REF-2", Title: "Reference Title"},
@@ -332,7 +332,7 @@ func TestReference_Formats(t *testing.T) {
 
 // TestCWEItem_UnicodeInFields validates unicode handling.
 func TestCWEItem_UnicodeInFields(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCWEItem_UnicodeInFields", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCWEItem_UnicodeInFields", nil, func(t *testing.T, tx *gorm.DB) {
 		item := CWEItem{
 			ID:                    "CWE-79",
 			Name:                  "跨站脚本-XSS",

--- a/pkg/notes/models_test.go
+++ b/pkg/notes/models_test.go
@@ -1,8 +1,8 @@
 package notes
 
 import (
-"gorm.io/gorm"
-"github.com/cyw0ng95/v2e/pkg/testutils"
+	"github.com/cyw0ng95/v2e/pkg/testutils"
+	"gorm.io/gorm"
 	"testing"
 	"time"
 )
@@ -10,7 +10,7 @@ import (
 // MockDBConnection creates a mock database connection for testing
 // In real tests, this would connect to a test database
 func TestBookmarkModel(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestBookmarkModel", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestBookmarkModel", nil, func(t *testing.T, tx *gorm.DB) {
 		// Test basic struct properties
 		b := &BookmarkModel{
 			GlobalItemID:  "global-item-123",
@@ -43,7 +43,7 @@ func TestBookmarkModel(t *testing.T) {
 }
 
 func TestBookmarkHistoryModel(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestBookmarkHistoryModel", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestBookmarkHistoryModel", nil, func(t *testing.T, tx *gorm.DB) {
 		now := time.Now()
 		h := &BookmarkHistoryModel{
 			BookmarkID: 1,
@@ -69,7 +69,7 @@ func TestBookmarkHistoryModel(t *testing.T) {
 }
 
 func TestNoteModel(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestNoteModel", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestNoteModel", nil, func(t *testing.T, tx *gorm.DB) {
 		now := time.Now()
 		n := &NoteModel{
 			BookmarkID: 1,
@@ -94,7 +94,7 @@ func TestNoteModel(t *testing.T) {
 }
 
 func TestMemoryCardModel(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestMemoryCardModel", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestMemoryCardModel", nil, func(t *testing.T, tx *gorm.DB) {
 		now := time.Now()
 		c := &MemoryCardModel{
 			BookmarkID: 1,
@@ -134,7 +134,7 @@ func TestMemoryCardModel(t *testing.T) {
 }
 
 func TestLearningSessionModel(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestLearningSessionModel", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestLearningSessionModel", nil, func(t *testing.T, tx *gorm.DB) {
 		now := time.Now()
 		s := &LearningSessionModel{
 			SessionStart:  now,
@@ -158,7 +158,7 @@ func TestLearningSessionModel(t *testing.T) {
 }
 
 func TestCrossReferenceModel(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCrossReferenceModel", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCrossReferenceModel", nil, func(t *testing.T, tx *gorm.DB) {
 		now := time.Now()
 		cr := &CrossReferenceModel{
 			SourceItemID:     "global-source-123",
@@ -198,7 +198,7 @@ func TestCrossReferenceModel(t *testing.T) {
 }
 
 func TestGlobalItemModel(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestGlobalItemModel", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestGlobalItemModel", nil, func(t *testing.T, tx *gorm.DB) {
 		now := time.Now()
 		gi := &GlobalItemModel{
 			ID:        "global-item-789",
@@ -233,7 +233,7 @@ func TestGlobalItemModel(t *testing.T) {
 }
 
 func TestLearningStateConstants(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestLearningStateConstants", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestLearningStateConstants", nil, func(t *testing.T, tx *gorm.DB) {
 		states := []LearningState{
 			LearningStateToReview,
 			LearningStateLearning,
@@ -258,7 +258,7 @@ func TestLearningStateConstants(t *testing.T) {
 }
 
 func TestCardRatingConstants(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestCardRatingConstants", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestCardRatingConstants", nil, func(t *testing.T, tx *gorm.DB) {
 		ratings := []CardRating{
 			CardRatingAgain,
 			CardRatingHard,
@@ -283,7 +283,7 @@ func TestCardRatingConstants(t *testing.T) {
 }
 
 func TestRelationshipTypeConstants(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestRelationshipTypeConstants", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestRelationshipTypeConstants", nil, func(t *testing.T, tx *gorm.DB) {
 		relationships := []RelationshipType{
 			RelationshipTypeRelatedTo,
 			RelationshipTypeExploits,
@@ -312,7 +312,7 @@ func TestRelationshipTypeConstants(t *testing.T) {
 }
 
 func TestBookmarkActionConstants(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestBookmarkActionConstants", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestBookmarkActionConstants", nil, func(t *testing.T, tx *gorm.DB) {
 		actions := []BookmarkAction{
 			BookmarkActionCreated,
 			BookmarkActionUpdated,
@@ -341,7 +341,7 @@ func TestBookmarkActionConstants(t *testing.T) {
 }
 
 func TestItemTypeConstants(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestItemTypeConstants", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestItemTypeConstants", nil, func(t *testing.T, tx *gorm.DB) {
 		types := []ItemType{
 			ItemTypeCVE,
 			ItemTypeCWE,

--- a/pkg/proc/message_test.go
+++ b/pkg/proc/message_test.go
@@ -1,17 +1,17 @@
 package proc
 
 import (
-"gorm.io/gorm"
-"github.com/cyw0ng95/v2e/pkg/testutils"
 	"encoding/json"
 	"errors"
+	"github.com/cyw0ng95/v2e/pkg/testutils"
+	"gorm.io/gorm"
 	"testing"
 
 	"github.com/bytedance/sonic"
 )
 
 func TestMessageType_Constants(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestMessageType_Constants", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestMessageType_Constants", nil, func(t *testing.T, tx *gorm.DB) {
 		tests := []struct {
 			msgType  MessageType
 			expected string
@@ -34,7 +34,7 @@ func TestMessageType_Constants(t *testing.T) {
 }
 
 func TestNewMessage(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestNewMessage", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestNewMessage", nil, func(t *testing.T, tx *gorm.DB) {
 		msg := NewMessage(MessageTypeRequest, "test-id")
 
 		if msg == nil {
@@ -51,7 +51,7 @@ func TestNewMessage(t *testing.T) {
 }
 
 func TestNewRequestMessage(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestNewRequestMessage", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestNewRequestMessage", nil, func(t *testing.T, tx *gorm.DB) {
 		type TestPayload struct {
 			Command string   `json:"command"`
 			Args    []string `json:"args"`
@@ -87,7 +87,7 @@ func TestNewRequestMessage(t *testing.T) {
 }
 
 func TestNewRequestMessage_NilPayload(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestNewRequestMessage_NilPayload", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestNewRequestMessage_NilPayload", nil, func(t *testing.T, tx *gorm.DB) {
 		msg, err := NewRequestMessage("req-1", nil)
 		if err != nil {
 			t.Fatalf("NewRequestMessage with nil payload failed: %v", err)
@@ -101,7 +101,7 @@ func TestNewRequestMessage_NilPayload(t *testing.T) {
 }
 
 func TestNewResponseMessage(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestNewResponseMessage", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestNewResponseMessage", nil, func(t *testing.T, tx *gorm.DB) {
 		type TestResponse struct {
 			Status string `json:"status"`
 			Result int    `json:"result"`
@@ -137,7 +137,7 @@ func TestNewResponseMessage(t *testing.T) {
 }
 
 func TestNewEventMessage(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestNewEventMessage", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestNewEventMessage", nil, func(t *testing.T, tx *gorm.DB) {
 		type TestEvent struct {
 			EventType string `json:"event_type"`
 			Data      string `json:"data"`
@@ -170,7 +170,7 @@ func TestNewEventMessage(t *testing.T) {
 }
 
 func TestNewErrorMessage(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestNewErrorMessage", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestNewErrorMessage", nil, func(t *testing.T, tx *gorm.DB) {
 		testErr := errors.New("test error occurred")
 		msg := NewErrorMessage("err-1", testErr)
 
@@ -188,7 +188,7 @@ func TestNewErrorMessage(t *testing.T) {
 }
 
 func TestNewErrorMessage_NilError(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestNewErrorMessage_NilError", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestNewErrorMessage_NilError", nil, func(t *testing.T, tx *gorm.DB) {
 		msg := NewErrorMessage("err-1", nil)
 
 		if msg.Type != MessageTypeError {
@@ -202,7 +202,7 @@ func TestNewErrorMessage_NilError(t *testing.T) {
 }
 
 func TestMessage_UnmarshalPayload_NoPayload(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestMessage_UnmarshalPayload_NoPayload", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestMessage_UnmarshalPayload_NoPayload", nil, func(t *testing.T, tx *gorm.DB) {
 		msg := NewMessage(MessageTypeRequest, "test-id")
 
 		var result map[string]interface{}
@@ -216,7 +216,7 @@ func TestMessage_UnmarshalPayload_NoPayload(t *testing.T) {
 }
 
 func TestMessage_Marshal(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestMessage_Marshal", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestMessage_Marshal", nil, func(t *testing.T, tx *gorm.DB) {
 		msg := NewMessage(MessageTypeRequest, "test-id")
 		msg.Payload = json.RawMessage(`{"test":"value"}`)
 
@@ -246,7 +246,7 @@ func TestMessage_Marshal(t *testing.T) {
 }
 
 func TestUnmarshal(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestUnmarshal", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestUnmarshal", nil, func(t *testing.T, tx *gorm.DB) {
 		data := []byte(`{"type":"request","id":"test-id","payload":{"key":"value"}}`)
 
 		msg, err := Unmarshal(data)
@@ -274,7 +274,7 @@ func TestUnmarshal(t *testing.T) {
 }
 
 func TestUnmarshal_InvalidJSON(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestUnmarshal_InvalidJSON", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestUnmarshal_InvalidJSON", nil, func(t *testing.T, tx *gorm.DB) {
 		data := []byte(`{invalid json}`)
 
 		_, err := Unmarshal(data)
@@ -286,7 +286,7 @@ func TestUnmarshal_InvalidJSON(t *testing.T) {
 }
 
 func TestMessage_MarshalUnmarshal_RoundTrip(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestMessage_MarshalUnmarshal_RoundTrip", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestMessage_MarshalUnmarshal_RoundTrip", nil, func(t *testing.T, tx *gorm.DB) {
 		type TestData struct {
 			Name  string `json:"name"`
 			Value int    `json:"value"`
@@ -331,7 +331,7 @@ func TestMessage_MarshalUnmarshal_RoundTrip(t *testing.T) {
 }
 
 func TestMarshalFast(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestMarshalFast", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestMarshalFast", nil, func(t *testing.T, tx *gorm.DB) {
 		msg := &Message{
 			Type: MessageTypeRequest,
 			ID:   "test-id",
@@ -360,7 +360,7 @@ func TestMarshalFast(t *testing.T) {
 }
 
 func TestUnmarshalFast(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestUnmarshalFast", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestUnmarshalFast", nil, func(t *testing.T, tx *gorm.DB) {
 		original := &Message{
 			Type: MessageTypeResponse,
 			ID:   "resp-1",
@@ -390,7 +390,7 @@ func TestUnmarshalFast(t *testing.T) {
 }
 
 func TestPutMessage(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestPutMessage", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestPutMessage", nil, func(t *testing.T, tx *gorm.DB) {
 		msg := GetMessage()
 		msg.Type = MessageTypeEvent
 		msg.ID = "event-1"

--- a/pkg/ssg/remote/git_test.go
+++ b/pkg/ssg/remote/git_test.go
@@ -2,15 +2,15 @@
 package remote
 
 import (
-"gorm.io/gorm"
-"github.com/cyw0ng95/v2e/pkg/testutils"
+	"github.com/cyw0ng95/v2e/pkg/testutils"
+	"gorm.io/gorm"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestNewGitClient(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestNewGitClient", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestNewGitClient", nil, func(t *testing.T, tx *gorm.DB) {
 		tests := []struct {
 			name     string
 			repoURL  string
@@ -49,7 +49,7 @@ func TestNewGitClient(t *testing.T) {
 }
 
 func TestDefaultRepoURL(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestDefaultRepoURL", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestDefaultRepoURL", nil, func(t *testing.T, tx *gorm.DB) {
 		url := DefaultRepoURL()
 		if url == "" {
 			t.Error("DefaultRepoURL returned empty string")
@@ -62,7 +62,7 @@ func TestDefaultRepoURL(t *testing.T) {
 }
 
 func TestDefaultRepoPath(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestDefaultRepoPath", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestDefaultRepoPath", nil, func(t *testing.T, tx *gorm.DB) {
 		path := DefaultRepoPath()
 		if path == "" {
 			t.Error("DefaultRepoPath returned empty string")
@@ -75,7 +75,7 @@ func TestDefaultRepoPath(t *testing.T) {
 }
 
 func TestMatchGuideFilePattern(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestMatchGuideFilePattern", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestMatchGuideFilePattern", nil, func(t *testing.T, tx *gorm.DB) {
 		tests := []struct {
 			name     string
 			filename string
@@ -131,7 +131,7 @@ func TestMatchGuideFilePattern(t *testing.T) {
 }
 
 func TestGitClient_GetFilePath(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestGitClient_GetFilePath", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestGitClient_GetFilePath", nil, func(t *testing.T, tx *gorm.DB) {
 		client := NewGitClient("", "/test/repo")
 		want := filepath.Join("/test/repo", "guides", "test.html")
 		got := client.GetFilePath("test.html")
@@ -144,7 +144,7 @@ func TestGitClient_GetFilePath(t *testing.T) {
 
 // TestGitClient_Clone_Error tests Clone with various error conditions.
 func TestGitClient_Clone_Error(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestGitClient_Clone_Error", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestGitClient_Clone_Error", nil, func(t *testing.T, tx *gorm.DB) {
 		// Create a temporary directory for testing
 		tempDir := t.TempDir()
 		client := NewGitClient("", filepath.Join(tempDir, "test-repo"))
@@ -161,7 +161,7 @@ func TestGitClient_Clone_Error(t *testing.T) {
 
 // TestRepoStatus validation.
 func TestRepoStatus(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestRepoStatus", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestRepoStatus", nil, func(t *testing.T, tx *gorm.DB) {
 		status := &RepoStatus{
 			CommitHash: "abc1234",
 			Branch:     "main",
@@ -183,7 +183,7 @@ func TestRepoStatus(t *testing.T) {
 
 // TestListGuideFiles tests listing guide files in a directory structure.
 func TestListGuideFiles_EmptyDir(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestListGuideFiles_EmptyDir", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestListGuideFiles_EmptyDir", nil, func(t *testing.T, tx *gorm.DB) {
 		// Create empty temp directory
 		tempDir := t.TempDir()
 		client := NewGitClient("", tempDir)
@@ -207,7 +207,7 @@ func TestListGuideFiles_EmptyDir(t *testing.T) {
 
 // TestListGuideFiles_NoGuidesDir tests when guides directory doesn't exist.
 func TestListGuideFiles_NoGuidesDir(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestListGuideFiles_NoGuidesDir", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestListGuideFiles_NoGuidesDir", nil, func(t *testing.T, tx *gorm.DB) {
 		// Create empty temp directory (no guides subdirectory)
 		tempDir := t.TempDir()
 		client := NewGitClient("", tempDir)
@@ -222,7 +222,7 @@ func TestListGuideFiles_NoGuidesDir(t *testing.T) {
 
 // TestListGuideFiles_WithMixedFiles tests listing with mixed file types.
 func TestListGuideFiles_WithMixedFiles(t *testing.T) {
-	testutils.Run(t, testutils.Level2, "TestListGuideFiles_WithMixedFiles", nil, func(t *testing.T, tx *gorm.DB) {
+	testutils.Run(t, testutils.Level1, "TestListGuideFiles_WithMixedFiles", nil, func(t *testing.T, tx *gorm.DB) {
 		// Create temp directory with guides subdirectory
 		tempDir := t.TempDir()
 		guidesDir := filepath.Join(tempDir, "guides")
@@ -234,8 +234,8 @@ func TestListGuideFiles_WithMixedFiles(t *testing.T) {
 		testFiles := []string{
 			"ssg-al2023-guide-cis.html",
 			"ssg-al2023-guide-index.html",
-			"ssg-al2023-ds.xml",          // Not a guide
-			"other.html",                  // Not a guide pattern
+			"ssg-al2023-ds.xml", // Not a guide
+			"other.html",        // Not a guide pattern
 		}
 
 		for _, name := range testFiles {


### PR DESCRIPTION
- Fixed 119 test cases that were incorrectly marked as Level2 (integration tests)
- These tests are pure logic tests with no database dependencies
- Should be marked as Level1 (fundamental tests) for faster unit testing
- Affected test files include serialization, message handling, logging, worker pools, and model validation tests
- This change improves CI/CD efficiency by allowing faster test execution at Level1

Modified files:
- pkg/cve/types_test.go (4 tests)
- pkg/cve/types_format_test.go (6 tests)
- pkg/cve/taskflow/state_test.go (2 tests)
- pkg/proc/message_test.go (16 tests)
- pkg/common/log_test.go (14 tests)
- pkg/common/workerpool/workerpool_test.go (6 tests)
- pkg/notes/models_test.go (12 tests)
- pkg/broker/api_test.go (2 tests)
- cmd/v2broker/mq/bus_test.go (6 tests)
- cmd/v2broker/core/rpc_test.go (6 tests)
- pkg/ssg/remote/git_test.go (10 tests)
- pkg/cwe/types_format_test.go (9 tests)
- pkg/capec/types_format_test.go (9 tests)
- pkg/attack/types_test.go (7 tests)
- pkg/attack/types_format_test.go (9 tests)
- pkg/capec/types_test.go (1 test)

Total: 119 test cases adjusted

## Summary by Sourcery

Tests:
- Lower the execution level of serialization, logging, worker pool, broker RPC/bus, git remote, and model validation tests from Level2 to Level1 so they run as fast unit tests instead of integration tests.